### PR TITLE
generic-service cleanup with breaking changes

### DIFF
--- a/charts/generic-service/README.md
+++ b/charts/generic-service/README.md
@@ -23,100 +23,67 @@ app:
   name: myservice
 
   image:
-    registry: docker.axoom.cloud # replaced with docker-ci.axoom.cloud for pre-release builds by build server
-    repository: services/myvendor-myservice
-    tag: latest # replaced with specific version number by build server
-
-    alerting:
-      enabled: true
-      labels:
-        team: myteam
-
-  # resources:
-  #   ...
-
-  # livenessProbe:
-  #   ...
-
-  # readinessProbe:
-  #   ...
+    registry: eu.gcr.io
+    repository: axoom-image/myteam/myservice
 
   env:
     SOME_CONFIG: some-value
-```
 
-For configuration that varies between instances add something like this to your `helmfile.yaml`:
+  resources:
+    requests:
+      memory: 256M
+    limits:
+      memory: 512M
 
-```yaml
-releases:
-  - name: '{{ requiredEnv "TENANT_ID" }}-myservice' # Sets the release specific asset name, containing the tenant's id.
-    namespace: '{{ requiredEnv "TENANT_ID" }}' # Sets the release specific k8s namespace: the tenant's id.
-    chart: ./ # Use the chart from this repository.
-    values:
-      - global:
-          tenant:
-            id: '{{ requiredEnv "TENANT_ID" }}'
-            domain: '{{ requiredEnv "PUBLIC_DOMAIN" }}'
-
-        app:
-          ingress:
-            enabled: true
-            domain: 'myservice-{{ requiredEnv "PUBLIC_DOMAIN" }}'
-          env:
-            OTHER_CONFIG: '{{ env "MYSERVICE_OTHER_CONFIG" | default "other-value" }}'
+  replicas: 2
 ```
 
 ## Values
 
-| Value                                     | Default                                               | Description                                                                                                               |
-|-------------------------------------------|-------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
-| `global.tenant.id`                        |                                                       | The tenant's id (used for labeling)                                                                                       |
-| `global.tenant.domain`                    |                                                       | The tenant's domain name (used for labeling)                                                                              |
-| `name`                                    | __required__                                          | The name of the service                                                                                                   |
-| `image.registry`                          | __required__ (`docker.io` for images from Docker Hub) | The Docker registry containing the image of the service                                                                   |
-| `image.authenticated`                     | `true`                                                | Controls whether to use credentials for pulling the image                                                                 |
-| `image.repository`                        | __required__                                          | The Docker Repository containing the image (excluding the Registry)                                                       |
-| `image.tag`                               | __required__                                          | The Docker Tag of the image to use                                                                                        |
-| `image.pullPolicy`                        | `IfNotPresent`                                        | Set to `Always` to try to pull new versions of the image                                                                  |
-| `replicas`                                | `1`                                                   | The number of instances of the service to run                                                                             |
-| `updateStrategy`                          | `RollingUpdate` (`Recreate` if `persistence.enabled`) | Controls whether all existing instances of the service must be shut down before new versions may be started.              |
-| `rbac.roles`                              | `[]`                                                  | The names of [namespaced Roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) the service shall have.    |
-| `rbac.clusterRoles`                       | `[]`                                                  | The names of [cluster-wide Roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/) the service shall have.  |
-| `persistence.enabled`                     | `false`                                               | Enables persistent storage for the service                                                                                |
-| `persistence.storageClass`                | `standard`                                            | The type of disk to use for storage (e.g., `standard` or `ssd`)                                                           |
-| `persistence.size`                        | `1G`                                                  | The size of the persistent volume to create for the service                                                               |
-| `persistence.mountPath`                   | __required if enabled__                               | The mount path for the storage inside the container                                                                       |
-| `secrets[0].name`                         | __required if used__                                  | The name of the Kubernetes secret to create                                                                               |
-| `secrets[0].mountPath`                    | __required if used__                                  | The mount path for the secret inside the container                                                                        |
-| `secrets[0].files`                        | `{}`                                                  | A dictionary mapping file names to file contents for secrets with base64 encoded values                                   |
-| `providedSecrets[0].name`                 | __required if used__                                  | The name of an existing Kubernetes secret                                                                                 |
-| `providedSecrets[0].mountPath`            | __required if used__                                  | The mount path for the secret inside the container                                                                        |
-| `providedSecrets[0].subPath`              |                                                       | The path of a single file in the secret relative to the given `mountPath`                                                 |
-| `hostAliases`                             | `[]`                                                  | [HostAliases](https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/)    |
-| `sidecars`                                | `[]`                                                  | Additional sidecar containers to be added to the pod.                                                                     |
-| `ingress.enabled`                         | `false`                                               | Enables HTTP ingress into the service                                                                                     |
-| `ingress.port`                            | `80`                                                  | The container port ingress traffic is forwarded to                                                                        |
-| `ingress.class`                           | `traefik-public`                                      | `traefik-public` for public internet, `traefik-internal` for private network, `cluster` for Kubernetes cluster only       |
-| `ingress.domain`                          |                                                       | The domain name under which the service is exposed (only for `traefik-public` and `traefik-internal`)                     |
-| `ingress.annotations`                     |                                                       | Additional annotations besides the ingress class to be added to the ingress. Put as `key: value` pairs                    |
-| `ingress.externalDnsTarget`               |                                                       | Domain name for the external-dns target (explicitly setting `external-dns.alpha.kubernetes.io/target` annotation)         |
-| `ingress.extendedRules`                   | `[]`                                                  | Additional ingress rules besides the one specified by the enabled ingress.                                                |
-| `monitoring.enabled`                      | `true`                                                | Enables Prometheus monitoring                                                                                             |
-| `monitoring.port`                         | `5000`                                                | The port which is scraped for monitoring data                                                                             |
-| `alerting.enabled`                        | `false`                                               | Enables default alert rules (unavailable pods, high memory usage, HTTP 4xx/5xx responses, slow response times)            |
-| `alerting.labels`                         | `{}`                                                  | Additional labels to apply to default alert rules                                                                         |
-| `alerting.memoryUsage.thresholdFactor`    | `0.9`                                                 | The maximum factor (between `0` and `1`) of memory usage to allow before alerting                                         |
-| `alerting.http4xxRatio.sampleInterval`    | `5m`                                                  | The time interval in which to measure ratio of HTTP 4xx responses for the current state                                   |
-| `alerting.http4xxRatio.referenceInterval` | `1d`                                                  | The time interval in which to measure ratio of HTTP 4xx responses as a reference for the normal state                     |
-| `alerting.http4xxRatio.thresholdFactor`   | `1.5`                                                 | The maximum factor between the current state and the normal state of HTTP 4xx response ratio to allow before alerting     |
-| `alerting.responseTime.sampleInterval`    | `1h`                                                  | The time interval in which to measure average HTTP response times for the current state                                   |
-| `alerting.responseTime.referenceInterval` | `1d`                                                  | The time interval in which to measure average HTTP response times for the normal state                                    |
-| `alerting.responseTime.thresholdFactor`   | `1.5`                                                 | The maximum factor between the current state and the normal state of HTTP response times to allow before alerting         |
-| `livenessProbe`                           |                                                       | Probe that causes the service to be restarted when failing                                                                |
-| `readinessProbe`                          |                                                       | Probe that prevents the service from receiving traffic when failing                                                       |
-| `resources`                               | Limits to 128M mem                                    | The resources requests and limits for the service                                                                         |
-| `env`                                     | `{}`                                                  | The environment variables passed to the service                                                                           |
-| `envFromField`                            | `{}`                                                  | Environment variables from fields. Key is the name of the env var and value is the fieldPath (e.g. `metadata.namespace`). |
-| `dns.policy`                              | `ClusterFirst`                                        | [DNS resolution policy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy)        |
-| `dns.config`                              | `{}`                                                  | [DNS Config](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-config)                   |
-| `podAntiAffinity`                         | based on `app.kubernetes.io/instance` label           | [Anti-Affinity](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/)                                       |
+| Value                                     | Default                 | Description                                                                                               |
+|-------------------------------------------|-------------------------|-----------------------------------------------------------------------------------------------------------|
+| `global.tenant.id`                        |                         | The tenant's id (used for labeling)                                                                       |
+| `name`                                    | __required__            | The name of the service                                                                                   |
+| `image.registry`                          | __required__            | The Registry containing the Docker Image to run (also used as the name of an optional Image Pull Secret)  |
+| `image.repository`                        | __required__            | The name of the Docker Image image to run (without the Registry)                                          |
+| `image.tag`                               | __required__            | The tag of the Docker Image to run                                                                        |
+| `image.pullPolicy`                        | `IfNotPresent`          | Set to `Always` to try to pull new versions of the Docker Image                                           |
+| `env`                                     | `{}`                    | The environment variables passed to the service                                                           |
+| `resources.requests`                      | `{memory: 64M}`         | The minimum resources requested/reserved for the service                                                  |
+| `resources.limits`                        | `{memory: 128M}`        | The maximum resources the service can use                                                                 |
+| `replicas`                                | `1`                     | The number of instances of the service to run (set at least `2` for Pod Distruption Budget)               |
+| `autoscaling.enabled`                     | `false`                 | Enables automatic starting of additional instances based on CPU load                                      |
+| `autoscaling.maxReplicas`                 | `3`                     | The maximum number of instances to run (must be larger than `replicas`)                                   |
+| `autoscaling.targetCpu`                   | `50`                    | The desired average CPU load in percent                                                                   |
+| `rollingUpdate`                           | `true`                  | Controls whether to wait for new versions to be up and running before shutting down old version           |
+| `nodeSelector`                            | `{}`                    | Node labels required for scheduling this service, also used as tolerations                                |
+| `persistence.enabled`                     | `false`                 | Enables persistent storage for the service                                                                |
+| `persistence.storageClass`                | `standard`              | The type of disk to use for storage (e.g., `standard` or `ssd`)                                           |
+| `persistence.size`                        | `1G`                    | The size of the persistent volume to create for the service                                               |
+| `persistence.mountPath`                   | __required if enabled__ | The mount path for the storage inside the container                                                       |
+| `secrets[].name`                          | __required if used__    | The name of the Kubernetes Secret                                                                         |
+| `secrets[].mountPath`                     | __required if used__    | The mount path for the Secret inside the container                                                        |
+| `secrets[].subPath`                       |                         | The path of a single file in the secret relative to the given `mountPath`                                 |
+| `secrets[].files`                         |                         | Secret content as map of file names to base64-encoded content; leave empty to reference existing secret   |
+| `ingress.enabled`                         | `false`                 | Enables HTTP ingress into the service                                                                     |
+| `ingress.port`                            | `80`                    | The container port ingress traffic is routed to                                                           |
+| `ingress.class`                           | `traefik-public`        | Specifies the ingress controller to use; `cluster` for cluster-internal access with no ingress controller |
+| `ingress.domain`                          | __required if enabled__ | The domain name under which the service is exposed (not for `cluster`)                                    |
+| `ingress.additionalDomains`               | `[]`                    | Additional domain names under which the service is exposed (not for `cluster`)                            |
+| `ingress.annotations`                     | `{}`                    | Additional annotations besides the ingress class to be added to the ingress  (not for `cluster`)          |
+| `livenessProbe`                           |                         | Probe that causes the service to be restarted when failing                                                |
+| `readinessProbe`                          |                         | Probe that prevents the service from receiving traffic when failing                                       |
+| `monitoring.enabled`                      | `true`                  | Enables Prometheus monitoring                                                                             |
+| `monitoring.port`                         | `5000`                  | The port which is scraped for monitoring data                                                             |
+| `alerting.enabled`                        | `false`                 | Enables generic alert rules (unavailable pods, high memory usage, HTTP 4xx/5xx responses, slow responses) |
+| `alerting.labels`                         | `{}`                    | Labels to apply to generic alert rules in addition to `component` and `severity`                          |
+| `alerting.memoryUsage.thresholdFactor`    | `0.9`                   | The maximum factor (between `0` and `1`) of memory usage allowed                                          |
+| `alerting.http4xxRatio.sampleInterval`    | `5m`                    | The time interval in which to measure ratio of HTTP 4xx responses for the current state                   |
+| `alerting.http4xxRatio.referenceInterval` | `1d`                    | The time interval in which to measure ratio of HTTP 4xx responses as a reference for the normal state     |
+| `alerting.http4xxRatio.thresholdFactor`   | `1.5`                   | The maximum factor between the current state and the normal state of HTTP 4xx response ratio allowed      |
+| `alerting.responseTime.sampleInterval`    | `1h`                    | The time interval in which to measure average HTTP response times for the current state                   |
+| `alerting.responseTime.referenceInterval` | `1d`                    | The time interval in which to measure average HTTP response times for the normal state                    |
+| `alerting.responseTime.thresholdFactor`   | `1.5`                   | The maximum factor between the current state and the normal state of HTTP response times allowed          |
+| `sidecars`                                | `[]`                    | Additional sidecar containers to be added to the Pod                                                      |
+| `rbac.roles`                              | `[]`                    | Namespace-specific Kubernetes RBAC Roles to assign to the service                                         |
+| `rbac.clusterRoles`                       | `[]`                    | Cluster-wide Kubernetes RBAC Roles to assign to the service                                               |

--- a/charts/generic-service/README.md
+++ b/charts/generic-service/README.md
@@ -11,7 +11,7 @@ You can usually delete your entire `templates` directory when using this chart. 
 ```yaml
 dependencies:
   - name: generic-service
-    version: 4.3.0
+    version: 5.0.0
     repository: '@axoom-github'
     alias: app
 ```

--- a/charts/generic-service/templates/_helpers.tpl
+++ b/charts/generic-service/templates/_helpers.tpl
@@ -17,8 +17,4 @@ tenantId: '{{ required "Set global.tenant.id" .Values.global.tenant.id }}'
 axoom.com/customer: '{{ required "Set global.tenant.id" .Values.global.tenant.id }}'
 {{- end }}
 
-{{- if .Values.global.tenant.domain }}
-tenantDomain: '{{ required "Set global.tenant.domain" .Values.global.tenant.domain }}'
-{{- end }}
-
 {{- end }}

--- a/charts/generic-service/templates/autoscaler.yaml
+++ b/charts/generic-service/templates/autoscaler.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.autoscaling.enabled }}
+
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Values.name }}
+  labels:
+{{ include "axoom.default-labels" . | indent 4 }}
+
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Values.name }}
+  minReplicas: {{ .Values.replicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCpu }}
+
+{{- end }}

--- a/charts/generic-service/templates/deployment.yaml
+++ b/charts/generic-service/templates/deployment.yaml
@@ -1,4 +1,3 @@
-{{- if gt .Values.replicas 0.0 }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -13,13 +12,10 @@ spec:
     matchLabels:
 {{ include "axoom.selector-labels" . | indent 6 }}
 
+  {{- if not .Values.rollingUpdate }}
   strategy:
-    {{- if .Values.persistence.enabled }}
-    # Containers with volumes usually cannot perform rolling updates
-    type: {{ .Values.updateStrategy | default "Recreate" }}
-    {{- else}}
-    type: {{ .Values.updateStrategy | default "RollingUpdate" }}
-    {{- end}}
+    type: Recreate
+  {{- end}}
 
   template:
     metadata:
@@ -38,47 +34,42 @@ spec:
           secret:
             secretName: {{ .name }}
         {{- end }}
-        {{- range .Values.providedSecrets }}
-        - name: {{ .name }}
-          secret:
-            secretName: {{ .name }}
-        {{- end }}
 
-      {{- if .Values.image.authenticated }}
       imagePullSecrets:
         - name: '{{ .Values.image.registry }}'
-      {{- end }}
 
       {{- if or .Values.rbac.roles .Values.rbac.clusterRoles }}
       serviceAccountName: {{ .Values.name }}
       {{- end }}
 
-      dnsPolicy: {{ .Values.dns.policy }}
-      {{- if .Values.dns.config }}
-
-      dnsConfig:
-{{ toYaml .Values.dns.config | indent 8 }}
-      {{- end }}
-
-      {{- if .Values.hostAliases }}
-      hostAliases:
-{{ toYaml .Values.hostAliases | indent 8 }}
-      {{- end }}
 
       affinity:
         podAntiAffinity:
-          {{- if .Values.podAntiAffinity }}
-{{ toYaml .Values.podAntiAffinity | indent 10 }}
-          {{- else }}
           requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchExpressions:
-                  - key: 'app.kubernetes.io/instance'
-                    operator: In
-                    values:
-                    - {{ .Release.Name }}
-              topologyKey: 'kubernetes.io/hostname'
-          {{- end }}
+            # Never schedule multiple replicas on the same node
+            - topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+{{ include "axoom.selector-labels" . | indent 20 }}
+          preferredDuringSchedulingIgnoredDuringExecution:
+            # Try to avoid scheduling multiple replicas in the same zone
+            - weight: 100
+              topologyKey: failure-domain.beta.kubernetes.io/zone
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+{{ include "axoom.selector-labels" . | indent 20 }}
+
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      tolerations:
+        {{- range $key, $val := .Values.nodeSelector }}
+        - key: {{ $key | quote }}
+          operator: Equal
+          value: {{ $val | quote }}
+        {{- end }}
+      {{- end }}
 
       containers:
         - name: {{ .Values.name }}
@@ -93,10 +84,6 @@ spec:
             {{- range .Values.secrets }}
             - name: {{ .name }}
               mountPath: {{ required "Set secrets.mountPath" .mountPath }}
-            {{- end }}
-            {{- range .Values.providedSecrets }}
-            - name: {{ .name }}
-              mountPath: {{ .mountPath }}
               {{- if .subPath }}
               subPath: {{ .subPath }}
               {{- end }}
@@ -130,15 +117,9 @@ spec:
             - name: {{ $key | quote }}
               value: {{ $val | quote }}
             {{- end }}
-            {{- range $key, $val := .Values.envFromField }}
-            - name: {{ $key | quote }}
-              valueFrom:
-                fieldRef:
-                  fieldPath: {{ $val }}
-            {{- end }}
 
-          # Delay shutdown to give ingress controller time to reroute traffic
           {{- if .Values.ingress.enabled }}
+          # Delay shutdown to give ingress controller time to reroute traffic
           lifecycle:
             preStop:
               exec:
@@ -148,4 +129,3 @@ spec:
         {{- if .Values.sidecars }}
 {{ toYaml .Values.sidecars | indent 8 }}
         {{- end }}
-{{- end }}

--- a/charts/generic-service/templates/deployment.yaml
+++ b/charts/generic-service/templates/deployment.yaml
@@ -21,6 +21,10 @@ spec:
     metadata:
       labels:
 {{ include "axoom.default-labels" . | indent 8 }}
+{{- if .Values.secrets -}}
+      annotations:
+        checksum/secrets: {{ .Values.secrets | toJson | sha256sum }}
+{{- end }}
 
     spec:
       volumes:

--- a/charts/generic-service/templates/ingress.yaml
+++ b/charts/generic-service/templates/ingress.yaml
@@ -7,13 +7,10 @@ metadata:
   labels:
 {{ include "axoom.default-labels" . | indent 4 }}
   annotations:
+    kubernetes.io/ingress.class: {{ .Values.ingress.class }}
   {{- range $key, $value := .Values.ingress.annotations }}
     {{ $key }}: {{ $value | quote }}
   {{- end }}
-  {{- if .Values.ingress.externalDnsTarget }}
-    external-dns.alpha.kubernetes.io/target: {{ .Values.ingress.externalDnsTarget }}
-  {{- end }}
-    kubernetes.io/ingress.class: {{ .Values.ingress.class }}
 
 spec:
   rules:
@@ -23,6 +20,14 @@ spec:
           - backend:
               serviceName: {{ .Values.name }}
               servicePort: ingress
-{{ if .Values.ingress.extendedRules }}{{ toYaml .Values.ingress.extendedRules | indent 4 }}{{ end }}
+    {{- $root := . -}}
+    {{- range .Values.ingress.additionalDomains }}
+    - host: '{{ . }}'
+      http:
+        paths:
+          - backend:
+              serviceName: {{ $root.Values.name }}
+              servicePort: ingress
+    {{- end }}
 
 {{- end }}

--- a/charts/generic-service/templates/monitoring.yaml
+++ b/charts/generic-service/templates/monitoring.yaml
@@ -19,6 +19,5 @@ spec:
     - axoom.com/customer
     - app
     - release
-    - tenantDomain
     - tenantId
 {{- end }}

--- a/charts/generic-service/templates/secret.yaml
+++ b/charts/generic-service/templates/secret.yaml
@@ -1,4 +1,5 @@
 {{- range .Values.secrets }}
+{{- if .files }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,4 +9,6 @@ data:
   {{- range $key, $val := .files }}
   {{ $key | quote }}: {{ $val }}
   {{- end }}
+{{- end }}
+---
 {{- end }}

--- a/charts/generic-service/templates/secret.yaml
+++ b/charts/generic-service/templates/secret.yaml
@@ -9,6 +9,6 @@ data:
   {{- range $key, $val := .files }}
   {{ $key | quote }}: {{ $val }}
   {{- end }}
-{{- end }}
 ---
+{{- end }}
 {{- end }}

--- a/charts/generic-service/values.yaml
+++ b/charts/generic-service/values.yaml
@@ -6,17 +6,29 @@ global:
 name: # required (e.g., axoom-myapp)
 
 image:
-  registry: # required
-  authenticated: true
-  repository: # required (e.g., apps/axoom-myapp)
+  registry: # required (e.g. gcr.io)
+  repository: # required (e.g., axoom-image/myteam/myservice)
   tag: # required (e.g., 1.0.0)
   pullPolicy: IfNotPresent
 
+env: {}
+
+resources:
+  requests:
+    memory: 64M
+  limits:
+    memory: 128M
+
 replicas: 1
 
-rbac:
-  roles: []
-  clusterRoles: []
+autoscaling:
+  enabled: false
+  maxReplicas: 3
+  targetCpu: 50
+
+rollingUpdate: true
+
+nodeSelector: {}
 
 persistence:
   enabled: false
@@ -26,20 +38,25 @@ persistence:
 
 secrets: []
 
-providedSecrets: []
-
-hostAliases: []
-
-sidecars: []
-
 ingress:
   enabled: false
-  class: traefik-public
-  domain: # e.g, harald.myaxoom.eu
-  externalDnsTarget: # optional, whatever is configured in external-dns
   port: 80
-  annotations: {} # additional annotations besides ingress class and optional external-dns
-  extendedRules: [] # additional rules besides the one specified by the enabled ingress
+  class: traefik-public
+  domain: # required if enabled, except for class "cluster"
+  additionalDomains: []
+  annotations: {} # additional annotations besides ingress class
+
+# livenessProbe:
+#   initialDelaySeconds: 10 # Allow for long startup
+#   httpGet:
+#     port: ingress
+#     path: /
+
+# readinessProbe:
+#   initialDelaySeconds: 2 # Accept traffic quickly
+#   httpGet:
+#     port: ingress
+#     path: /
 
 monitoring:
   enabled: true
@@ -59,30 +76,8 @@ alerting:
     referenceInterval: 1d
     thresholdFactor: 1.5
 
-# livenessProbe:
-#   initialDelaySeconds: 10 # Allow for long startup
-#   httpGet:
-#     port: ingress
-#     path: /
+sidecars: []
 
-# readinessProbe:
-#   initialDelaySeconds: 2 # Accept traffic quickly
-#   httpGet:
-#     port: ingress
-#     path: /
-
-resources:
-  requests:
-    # cpu: 0
-    memory: 64M
-  limits:
-    # cpu: 1
-    memory: 128M
-
-env: {}
-
-envFromField: {}
-
-dns:
-  policy: ClusterFirst
-  config:
+rbac:
+  roles: []
+  clusterRoles: []

--- a/charts/mongodb/README.md
+++ b/charts/mongodb/README.md
@@ -11,7 +11,7 @@ Then pull it in to your Chart as a dependency by adding this to your `requiremen
 ```yaml
 dependencies:
   - name: mongodb
-    version: 4.3.0
+    version: 5.0.0
     repository: '@axoom-github'
 ```
 

--- a/charts/pod-restarter/README.md
+++ b/charts/pod-restarter/README.md
@@ -11,7 +11,7 @@ Pull it in to your Chart as dependency by adding this to your `requirements.yaml
 ```yaml
 dependencies:
   - name: pod-restarter
-    version: 4.0.0
+    version: 5.0.0
     repository: '@axoom-github'
 ```
 


### PR DESCRIPTION
- Added autoscaling
- Added `nodeSelector`
- Removed `global.tenant.domain`
- Removed `image.authenticated` (always true now)
- Replaced `updateStrategy` with `rollingUpdate`
- Replaced `ingress.extendedRules` with `ingress.additionalDomains`
- Removed `ingress.externalDnsTarget` (covered by `ingress.annotations`)
- Replaced `providedSecrets` with support for unset `secrets[].files`
- Removed `podAntiAffinity`
- Removed `envFromField`
- Removed `hostAliases`
- Removed `dns.policy`
- Removed `dns.config`